### PR TITLE
Addition of `params` argument

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/R/spectralplot.R
+++ b/R/spectralplot.R
@@ -20,6 +20,6 @@ spectralplot<-function(flowfile, theme='viridis', save=FALSE, bins=512, normaliz
   if((class(flowfile)[1]=="flowSet")==TRUE){
     fsApply(flowfile,function(x)spectralplottingtool(x,theme,save,bins,normalize))
   } else{
-    spectralplottingtool(flowfile,theme,save,bins,normalize)
+    spectralplottingtool(flowfile,theme,save,bins,normalize,params)
   }
 }

--- a/R/spectralplot.R
+++ b/R/spectralplot.R
@@ -5,14 +5,15 @@
 #' colourblind accessible.
 #' Choose to save to the working directory or display in current session.
 #' Choose the number of bins (granularity) of the data.
+#' You can normalize to the max median signal for "clean" files.
 #' If you misspell an option it will give an error.
 #'
-#' @param flowfile A flowSet or flowFrame
-#' @param theme Choose a theme: 'viridis' (default), 'bigfoot', or 'aurora'
-#' @param save FALSE: in console (default). TRUE : as png file in working directory
-#' @param bins Choose the granularity of the data.
-#' @param normalize Normalize the data to the max median signal (only for clean signals).  TRUE or FALSE (default)
-#' @param params Default NULL. Specify parameters (in order) to plot. Only used if data are not from an Aurora, ID7000, or BigFoot instrument.
+#' @param flowfile A flowSet or flowFrame.
+#' @param theme Choose a theme: 'viridis' (default), 'bigfoot', or 'aurora'.
+#' @param save FALSE: in console (default). TRUE : as png file in working directory.
+#' @param bins Choose the granularity of the data. Between 200 and 1000 works well for most data.
+#' @param normalize Normalize the data to the max median signal (only for clean signals).  TRUE or FALSE (default).
+#' @param params Specify parameters (in order) to plot. If NULL (default), parameters will be selected based on the cytometer model.
 #' @return Images of full spectrum
 #' @export
 

--- a/R/spectralplot.R
+++ b/R/spectralplot.R
@@ -18,7 +18,7 @@
 
 spectralplot<-function(flowfile, theme='viridis', save=FALSE, bins=512, normalize=FALSE, params=NULL){
   if((class(flowfile)[1]=="flowSet")==TRUE){
-    fsApply(flowfile,function(x)spectralplottingtool(x,theme,save,bins,normalize))
+    fsApply(flowfile,function(x)spectralplottingtool(x,theme,save,bins,normalize,params))
   } else{
     spectralplottingtool(flowfile,theme,save,bins,normalize,params)
   }

--- a/R/spectralplot.R
+++ b/R/spectralplot.R
@@ -12,10 +12,11 @@
 #' @param save FALSE: in console (default). TRUE : as png file in working directory
 #' @param bins Choose the granularity of the data.
 #' @param normalize Normalize the data to the max median signal (only for clean signals).  TRUE or FALSE (default)
+#' @param params Default NULL. Specify parameters (in order) to plot. Only used if data are not from an Aurora, ID7000, or BigFoot instrument.
 #' @return Images of full spectrum
 #' @export
 
-spectralplot<-function(flowfile, theme='viridis', save=FALSE, bins=512, normalize=FALSE){
+spectralplot<-function(flowfile, theme='viridis', save=FALSE, bins=512, normalize=FALSE, params=NULL){
   if((class(flowfile)[1]=="flowSet")==TRUE){
     fsApply(flowfile,function(x)spectralplottingtool(x,theme,save,bins,normalize))
   } else{

--- a/R/spectralplottingtool.R
+++ b/R/spectralplottingtool.R
@@ -7,21 +7,23 @@
 #' colourblind accessible.
 #' Choose to save to the working directory or display in current session.
 #' Choose the number of bins (granularity) of the data.
-#' You can normlize to the max median signal for "clean" files.
+#' You can normalize to the max median signal for "clean" files.
 #' If you misspell an option it will give an error.
 #'
-#' @param flowfile A flowSet or flowFrame
-#' @param theme Choose a theme: 'viridis' (default), 'bigfoot', or 'aurora'
-#' @param save FALSE: in console (default). TRUE : as png file in working directory
+#' @param flowfile A flowSet or flowFrame.
+#' @param theme Choose a theme: 'viridis' (default), 'bigfoot', or 'aurora'.
+#' @param save FALSE: in console (default). TRUE : as png file in working directory.
 #' @param bins Choose the granularity of the data.  Between 200 and 1000 works well for most data.
-#' @param normalize Normalize the data to the max median signal (only for clean signals).  TRUE or FALSE (default)
-#' @param params Default NULL. Specify parameters (in order) to plot. Only used if data are not from an Aurora, ID7000, or BigFoot instrument.
+#' @param normalize Normalize the data to the max median signal (only for clean signals).  TRUE or FALSE (default).
+#' @param params Specify parameters (in order) to plot. If NULL (default), parameters will be selected based on the cytometer model.
 #' @return Images of full spectrum
 #' @export
 
 spectralplottingtool<-function(flowfile,theme='viridis', save=FALSE, bins=512, normalize=FALSE, params=NULL){
   data<-as.data.frame(exprs(flowfile))
-  if (flowfile@description$`$CYT`=="Aurora"){
+  if (!is.null(params)){
+    data2<-data[, params]
+  } else if (flowfile@description$`$CYT`=="Aurora"){
     data2<-data[,-grep("SC|Time", names(data))]
   } else if (flowfile@description$`$CYT`=="Bigfoot"){
     data2<-data[,-grep("SC", names(data))]
@@ -32,15 +34,9 @@ spectralplottingtool<-function(flowfile,theme='viridis', save=FALSE, bins=512, n
   } else if (flowfile@description$`$CYT`=="ID7000"){
     data2<-data[,-grep("SC", names(data))]
     data2<-data2[,grep("-A", names(data2))]
-  } else {
-    if(!is.null(params)){
-      print("This FCS file is not from an Aurora, Bigfoot, or ID7000. Using params argument.")
-      parameters<-params
-    } else{
+  } else{
       print("This FCS file is not from an Aurora, Bigfoot, or ID7000.  I will try and guess the relevant parameters...or I might just fail. Consider setting the params argument")
-      parameters<-grep("-A", names(data))
-      }
-    data2<-data[,parameters]
+    data2<-data[, grep("-A", names(data))]
   }
   dat_long2 <- tidyr::pivot_longer(data2, cols =1:length(colnames(data2)))
   if (normalize==FALSE){

--- a/R/spectralplottingtool.R
+++ b/R/spectralplottingtool.R
@@ -33,12 +33,16 @@ spectralplottingtool<-function(flowfile,theme='viridis', save=FALSE, bins=512, n
     data2<-data[,-grep("SC", names(data))]
     data2<-data2[,grep("-A", names(data2))]
   } else {
-    print("This FCS file is not from an Aurora, Bigfoot, or ID7000.  I will try and guess the relevant parameters...or I might just fail.
-          Consider setting the params argument")
-    cols<-if(!is.null(params)){factor(params, levels = params)} else{!grep("-A", names(data))}
-    data2<-data[,cols]
+    if(!is.null(params)){
+      print("This FCS file is not from an Aurora, Bigfoot, or ID7000. Using params argument.")
+      parameters<-params
+    } else{
+      print("This FCS file is not from an Aurora, Bigfoot, or ID7000.  I will try and guess the relevant parameters...or I might just fail. Consider setting the params argument")
+      parameters<-grep("-A", names(data))
+      }
+    data2<-data[,parameters]
   }
-  dat_long2 <- tidyr::pivot_longer(data2, cols =1:length(cols))
+  dat_long2 <- tidyr::pivot_longer(data2, cols =1:length(parameters))
   if (normalize==FALSE){
     if (theme=='viridis'){
       p<-ggplot(dat_long2, aes(factor(name, level = as.list(unique(dat_long2['name']))$name), value) ) +

--- a/R/spectralplottingtool.R
+++ b/R/spectralplottingtool.R
@@ -33,12 +33,12 @@ spectralplottingtool<-function(flowfile,theme='viridis', save=FALSE, bins=512, n
     data2<-data[,-grep("SC", names(data))]
     data2<-data2[,grep("-A", names(data2))]
   } else {
-    print("This FCS file is not from an Aurora, Bigfoot, or ID7000.  I will try and guess the relevant parameters...or I might just fail.\n
+    print("This FCS file is not from an Aurora, Bigfoot, or ID7000.  I will try and guess the relevant parameters...or I might just fail.
           Consider setting the params argument")
-    cols<-if(!is.null(factor(params, levels = params))){params} else{!grep("-A", names(data))}
+    cols<-if(!is.null(params)){factor(params, levels = params)} else{!grep("-A", names(data))}
     data2<-data[,cols]
   }
-  dat_long2 <- tidyr::pivot_longer(data2, cols =1:length(colnames(data2)))
+  dat_long2 <- tidyr::pivot_longer(data2, cols =1:length(cols))
   if (normalize==FALSE){
     if (theme=='viridis'){
       p<-ggplot(dat_long2, aes(factor(name, level = as.list(unique(dat_long2['name']))$name), value) ) +

--- a/R/spectralplottingtool.R
+++ b/R/spectralplottingtool.R
@@ -15,10 +15,11 @@
 #' @param save FALSE: in console (default). TRUE : as png file in working directory
 #' @param bins Choose the granularity of the data.  Between 200 and 1000 works well for most data.
 #' @param normalize Normalize the data to the max median signal (only for clean signals).  TRUE or FALSE (default)
+#' @param params Default NULL. Specify parameters (in order) to plot. Only used if data are not from an Aurora, ID7000, or BigFoot instrument.
 #' @return Images of full spectrum
 #' @export
 
-spectralplottingtool<-function(flowfile,theme='viridis', save=FALSE, bins=512, normalize=FALSE){
+spectralplottingtool<-function(flowfile,theme='viridis', save=FALSE, bins=512, normalize=FALSE, params=NULL){
   data<-as.data.frame(exprs(flowfile))
   if (flowfile@description$`$CYT`=="Aurora"){
     data2<-data[,-grep("SC|Time", names(data))]
@@ -32,8 +33,10 @@ spectralplottingtool<-function(flowfile,theme='viridis', save=FALSE, bins=512, n
     data2<-data[,-grep("SC", names(data))]
     data2<-data2[,grep("-A", names(data2))]
   } else {
-    print("This FCS file is not from an Aurora, Bigfoot, or ID7000.  I will try and guess the relevant parameters...or I might just fail.")
-    data2<-data[,grep("-A", names(data))]
+    print("This FCS file is not from an Aurora, Bigfoot, or ID7000.  I will try and guess the relevant parameters...or I might just fail.\n
+          Consider setting the params argument")
+    cols<-if(!is.null(factor(params, levels = params))){params} else{!grep("-A", names(data))}
+    data2<-data[,cols]
   }
   dat_long2 <- tidyr::pivot_longer(data2, cols =1:length(colnames(data2)))
   if (normalize==FALSE){

--- a/R/spectralplottingtool.R
+++ b/R/spectralplottingtool.R
@@ -42,7 +42,7 @@ spectralplottingtool<-function(flowfile,theme='viridis', save=FALSE, bins=512, n
       }
     data2<-data[,parameters]
   }
-  dat_long2 <- tidyr::pivot_longer(data2, cols =1:length(parameters))
+  dat_long2 <- tidyr::pivot_longer(data2, cols =1:length(colnames(data2)))
   if (normalize==FALSE){
     if (theme=='viridis'){
       p<-ggplot(dat_long2, aes(factor(name, level = as.list(unique(dat_long2['name']))$name), value) ) +

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ library(flowSpectrum)
 ff<-read.FCS(system.file("extdata", "PE.fcs", package = "flowSpectrum"))
 
 #create plots using spectralplot(). spectralpolt() will accept a flowFrame or a flowSet
-spectralplot(ff, theme='viridis', save=FALSE, bins=512, normalize=FALSE)
+spectralplot(ff, theme='viridis', save=FALSE, bins=512, normalize=FALSE, params=NULL)
 ```
 ![PE spectrum](/man/pe.png)
 
@@ -46,6 +46,8 @@ The save options are TRUE and FALSE.  TRUE will save a PNG into the working dire
 
 Set then granularity of the plot using ```bins =``` [a number].  I use something between 256 and 512.
 
-```Normalize = TRUE``` will produce a normlaized spectrum based on the max median intensity. 
+```Normalize = TRUE``` will produce a normalized spectrum based on the max median intensity. 
 
-Defaults are: ```theme='viridis', save=FALSE, bins=512, normalize=FALSE```
+Specify which parameters to plot (in the order specified) using ```params =``` [a character vector of parameter names].
+
+Defaults are: ```theme='viridis', save=FALSE, bins=512, normalize=FALSE, params=NULL```

--- a/flowSpectrum.Rproj
+++ b/flowSpectrum.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/man/spectralplot.Rd
+++ b/man/spectralplot.Rd
@@ -14,17 +14,17 @@ spectralplot(
 )
 }
 \arguments{
-\item{flowfile}{A flowSet or flowFrame}
+\item{flowfile}{A flowSet or flowFrame.}
 
-\item{theme}{Choose a theme: 'viridis' (default), 'bigfoot', or 'aurora'}
+\item{theme}{Choose a theme: 'viridis' (default), 'bigfoot', or 'aurora'.}
 
-\item{save}{FALSE: in console (default). TRUE : as png file in working directory}
+\item{save}{FALSE: in console (default). TRUE : as png file in working directory.}
 
-\item{bins}{Choose the granularity of the data.}
+\item{bins}{Choose the granularity of the data. Between 200 and 1000 works well for most data.}
 
-\item{normalize}{Normalize the data to the max median signal (only for clean signals).  TRUE or FALSE (default)}
+\item{normalize}{Normalize the data to the max median signal (only for clean signals).  TRUE or FALSE (default).}
 
-\item{params}{Default NULL. Specify parameters (in order) to plot. Only used if data are not from an Aurora, ID7000, or BigFoot instrument.}
+\item{params}{Specify parameters (in order) to plot. If NULL (default), parameters will be selected based on the cytometer model.}
 }
 \value{
 Images of full spectrum
@@ -35,5 +35,6 @@ Choose a theme: 'viridis', 'bigfoot', or 'aurora'.  Viridis is
 colourblind accessible.
 Choose to save to the working directory or display in current session.
 Choose the number of bins (granularity) of the data.
+You can normalize to the max median signal for "clean" files.
 If you misspell an option it will give an error.
 }

--- a/man/spectralplot.Rd
+++ b/man/spectralplot.Rd
@@ -9,7 +9,8 @@ spectralplot(
   theme = "viridis",
   save = FALSE,
   bins = 512,
-  normalize = FALSE
+  normalize = FALSE,
+  params = NULL
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ spectralplot(
 \item{bins}{Choose the granularity of the data.}
 
 \item{normalize}{Normalize the data to the max median signal (only for clean signals).  TRUE or FALSE (default)}
+
+\item{params}{Default NULL. Specify parameters (in order) to plot. Only used if data are not from an Aurora, ID7000, or BigFoot instrument.}
 }
 \value{
 Images of full spectrum

--- a/man/spectralplottingtool.Rd
+++ b/man/spectralplottingtool.Rd
@@ -14,17 +14,17 @@ spectralplottingtool(
 )
 }
 \arguments{
-\item{flowfile}{A flowSet or flowFrame}
+\item{flowfile}{A flowSet or flowFrame.}
 
-\item{theme}{Choose a theme: 'viridis' (default), 'bigfoot', or 'aurora'}
+\item{theme}{Choose a theme: 'viridis' (default), 'bigfoot', or 'aurora'.}
 
-\item{save}{FALSE: in console (default). TRUE : as png file in working directory}
+\item{save}{FALSE: in console (default). TRUE : as png file in working directory.}
 
 \item{bins}{Choose the granularity of the data.  Between 200 and 1000 works well for most data.}
 
-\item{normalize}{Normalize the data to the max median signal (only for clean signals).  TRUE or FALSE (default)}
+\item{normalize}{Normalize the data to the max median signal (only for clean signals).  TRUE or FALSE (default).}
 
-\item{params}{Default NULL. Specify parameters (in order) to plot. Only used if data are not from an Aurora, ID7000, or BigFoot instrument.}
+\item{params}{Specify parameters (in order) to plot. If NULL (default), parameters will be selected based on the cytometer model.}
 }
 \value{
 Images of full spectrum
@@ -37,6 +37,6 @@ Choose a theme: 'viridis', 'bigfoot', or 'aurora'.  Viridis is
 colourblind accessible.
 Choose to save to the working directory or display in current session.
 Choose the number of bins (granularity) of the data.
-You can normlize to the max median signal for "clean" files.
+You can normalize to the max median signal for "clean" files.
 If you misspell an option it will give an error.
 }

--- a/man/spectralplottingtool.Rd
+++ b/man/spectralplottingtool.Rd
@@ -9,7 +9,8 @@ spectralplottingtool(
   theme = "viridis",
   save = FALSE,
   bins = 512,
-  normalize = FALSE
+  normalize = FALSE,
+  params = NULL
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ spectralplottingtool(
 \item{bins}{Choose the granularity of the data.  Between 200 and 1000 works well for most data.}
 
 \item{normalize}{Normalize the data to the max median signal (only for clean signals).  TRUE or FALSE (default)}
+
+\item{params}{Default NULL. Specify parameters (in order) to plot. Only used if data are not from an Aurora, ID7000, or BigFoot instrument.}
 }
 \value{
 Images of full spectrum


### PR DESCRIPTION
Hi Chris,

Thanks for creating this package, I've been using it a lot lately. We're comparing the data we get from a bunch of the new Starbright dyes on our Aurora, Fortessa, and ZE5 and want to look at the "spectra" of each. Because I wanted to order the parameters of the Fortessa and ZE5 in the same excitation wavelength order as the Aurora, I added a `params` argument to the two functions from you package which defaults to NULL. If left as NULL, the functions behave exactly as they did, but if the data do not come from an Aurora, BigFoot, or ID7000, and the params argument is given, the parameters are plotted in the order given to this argument as a character vector.

I haven't made a pull request before, so I hope I'm doing this right! If it's of no use to you then don't worry about it, but if it is then please do some testing on your end that I haven't broken anything.

Best wishes
Hefin